### PR TITLE
Expose usage page and usage id of the USB HID device.

### DIFF
--- a/device.go
+++ b/device.go
@@ -277,3 +277,13 @@ func (d *Device) Product() string {
 func (d *Device) SerialNumber() string {
 	return d.serialNumber
 }
+
+// UsagePage returns the usage page of the USB HID device.
+func (d *Device) UsagePage() uint16 {
+	return d.usagePage
+}
+
+// Usage returns the usage identifier of the USB HID device.
+func (d *Device) Usage() uint16 {
+	return d.usage
+}

--- a/example_test.go
+++ b/example_test.go
@@ -18,6 +18,7 @@ func ExampleEnumerate() {
 		fmt.Printf("\tManufacturer:  %s\n", device.Manufacturer())
 		fmt.Printf("\tProduct:       %s\n", device.Product())
 		fmt.Printf("\tSerial Number: %s\n", device.SerialNumber())
+		fmt.Printf("\tUsage: 0x%02x/0x%02x\n", device.UsagePage(), device.Usage())
 	}
 }
 

--- a/example_test.go
+++ b/example_test.go
@@ -18,7 +18,7 @@ func ExampleEnumerate() {
 		fmt.Printf("\tManufacturer:  %s\n", device.Manufacturer())
 		fmt.Printf("\tProduct:       %s\n", device.Product())
 		fmt.Printf("\tSerial Number: %s\n", device.SerialNumber())
-		fmt.Printf("\tUsage: 0x%02x/0x%02x\n", device.UsagePage(), device.Usage())
+		fmt.Printf("\tUsage:         0x%04x/0x%04x\n", device.UsagePage(), device.Usage())
 	}
 }
 


### PR DESCRIPTION
Want to use usage to better device filtering. Especially in the case when one USB device may have different HID (e.g. Yubikey from #1)