### PR TITLE
Fix nil pointer dereference in macOS callbacks during device close

### DIFF
--- a/device_darwin.go
+++ b/device_darwin.go
@@ -329,6 +329,10 @@ type inputCtx struct {
 }
 
 func inputCallback(context unsafe.Pointer, result _IOReturn, sender uintptr, reportType _IOHIDReportType, reportId uint32, report uintptr, reportLength _CFIndex) {
+	if context == nil {
+		return
+	}
+
 	d := (*Device)(context)
 
 	d.extra.mtx.Lock()
@@ -354,6 +358,10 @@ func inputCallback(context unsafe.Pointer, result _IOReturn, sender uintptr, rep
 }
 
 func removalCallback(context unsafe.Pointer, result _IOReturn, sender uintptr) {
+	if context == nil {
+		return
+	}
+
 	d := (*Device)(context)
 
 	d.extra.mtx.Lock()
@@ -485,6 +493,10 @@ type resultCtx struct {
 }
 
 func resultCallback(context unsafe.Pointer, result _IOReturn, sender uintptr, reportType _IOHIDReportType, reportId uint32, report uintptr, reportLength _CFIndex) {
+	if context == nil {
+		return
+	}
+
 	ctx := (*resultCtx)(context)
 
 	if result != kIOReturnSuccess {


### PR DESCRIPTION
Hey! I've been having a great time using your streamdeck and usbhid libraries for a [little side project](https://github.com/phinze/belowdeck) - just a personal Stream Deck Plus dashboard for media controls, weather, and stuff like that. Thanks for your work on these libraries - they've been really easy to work with.

I ran into this crash, probably somewhere in a sleep/wake cycle:

```
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x2 addr=0x64 pc=0x102aad538]

goroutine 28713 [running]:
rafaelmartins.com/p/usbhid.resultCallback(0x0?, 0x0?, 0x0?, 0x0?, 0x0?, ...)
        device_darwin.go:470 +0x8c
```

It looks like there's a small race window where macOS IOKit callbacks can fire after `close()` starts unregistering them but before cleanup completes. When that happens, the `context` pointer can be nil.

This PR adds nil checks to the three callback functions (`inputCallback`, `removalCallback`, `resultCallback`) before dereferencing. Simple fix but should prevent the crash.