### PR TITLE
Add GetInputReportWithContext method to Device

### DIFF
--- a/device_darwin.go
+++ b/device_darwin.go
@@ -6,6 +6,7 @@ package usbhid
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"runtime"
@@ -468,7 +469,14 @@ func (d *Device) close() error {
 }
 
 func (d *Device) getInputReport() (byte, []byte, error) {
+	return d.getInputReportWithContext(context.Background(), nil)
+}
+
+func (d *Device) getInputReportWithContext(ctx context.Context, _ []byte) (byte, []byte, error) {
 	select {
+	case <-ctx.Done():
+		return 0, nil, ctx.Err()
+
 	case result := <-d.extra.inputCh:
 		if result.err != nil {
 			return 0, nil, result.err


### PR DESCRIPTION
Hello! I've been writing a program to work with a USB device that currently only has proprietary closed-source Windows software, and I've been trying out most of the available Go libraries. This one is my favorite because it doesn't use Cgo (unlike [github.com/google/gousb](https://github.com/google/gousb)) and it supports feature reports (unlike [github.com/go-ctap/hid](https://github.com/go-ctap/hid)).

However, the device that I am working with requires some new functionality. The device comes with a proprietary cable with an embedded HID-to-serial microcontroller. The cable shows up as a HID device even when the real device is not yet connected to the serial side. The protocol expects the host to regularly poll for the presence of the device by setting a feature report to configure the serial format, setting an output report to send a "ping" message, and then getting an input report containing the "pong". If the device is not attached to the cable, then the host is expected to stop waiting for the "pong" after a short timeout and try again.

Currently, it is not possible to implement this polling protocol with the library, because there is no way to interrupt a call to `GetInputReport`. (Closing the `Device` might work on some platforms, but that is overkill, and doesn't work on Linux anyway without opening with the ill-advised `O_NONBLOCK`.) This PR adds support for getting input reports with a `context.Context` that can cancel the read, like `gousb` / `libusb` supports.

I've tested this PR on Linux and Windows and it works correctly with the device in question. I do not have a macOS device, so **the macOS implementation is untested**. ⚠️ (However, it *does* compile, and the logic is the simplest of the three.)

---

This commit introduces a new `GetInputReportWithContext` method for `Device`, with implementations for all three backends. The new method is like `GetInputReport`, except that it also accepts a `context.Context` that cancels the request when the context is done. This enables callers to work with devices that may not always respond to every request.

In addition, the `GetInputReportWithContext` method also accepts a reusable buffer to use as storage space for the returned report content. This can reduce garbage collector pressure for some backends. While this functionality is not directly related to support for contexts, this commit takes advantage of the opportunity afforded by adding a new method to the API to also add this functionality (otherwise, there is a risk of ending up with methods like `GetInputReportWithContextAndBuffer`).

The new method is implemented differently on each platform:

- **For Linux**: The package now attaches an `epoll` file descriptor to the HIDRAW file and uses it to await read events in the context-aware code. By creating the `epoll` file descriptor when the device is first opened, the kernel does not need to recreate the polling structures between syscalls. Moreover, using `epoll` instead of `poll` avoids the need to import `golang.org/x/sys/unix`, or the inefficiencies of the `select` syscall.
- **For Windows**: The package now calls `WaitForSingleObject` when making a call with an overlapped operation before calling `GetOverlappedResult`, which allows it to regularly check for context completion, like the Linux solution. Unlike Linux, since the Windows implementation must begin a read operation with `ReadFile` before waiting, it is necessary to cancel the operation with `CancelIoEx` if the context is done before a report has been read.
- **For macOS**: Since reads are already performed in a separate goroutine and passed through a channel, adding context support merely involved adding a new clause to the existing `select` statement. However, unlike the other platforms, this commit makes no attempt to reuse the buffer provided by the caller. Attempting to make use of the buffer could be considered in future work.