### PR TITLE
fix: prevent panic when device returns empty feature/input report

### DIFF
--- a/device_darwin.go
+++ b/device_darwin.go
@@ -575,6 +575,9 @@ func (d *Device) getFeatureReport(reportId byte) ([]byte, error) {
 	}
 
 	if d.reportWithId {
+		if ctx.len <= 1 {
+			return nil, nil
+		}
 		return buf[1:ctx.len], nil
 	}
 	return buf[:ctx.len], nil

--- a/device_linux.go
+++ b/device_linux.go
@@ -240,6 +240,9 @@ func (d *Device) getInputReport() (byte, []byte, error) {
 	}
 
 	if d.reportWithId {
+		if n <= 1 {
+			return 0, nil, nil
+		}
 		return buf[0], buf[1:n], nil
 	}
 	return 0, buf[:n], nil
@@ -266,6 +269,9 @@ func (d *Device) getFeatureReport(reportId byte) ([]byte, error) {
 	if d.reportWithId {
 		start++
 		rv--
+	}
+	if rv <= 0 {
+		return nil, nil
 	}
 	return buf[start : start+rv], nil
 }

--- a/device_windows.go
+++ b/device_windows.go
@@ -465,6 +465,9 @@ func (d *Device) getFeatureReport(reportId byte) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
+	if n <= 1 {
+		return nil, nil
+	}
 	return buf[1:n], nil
 }
 


### PR DESCRIPTION
## Problem

`getFeatureReport()` panics with `slice bounds out of range [1:0]` when a USB HID device returns zero bytes for a feature report request. This affects all three platforms (Linux, macOS, Windows).

### Root Cause

When `reportWithId` is true, the return value from the ioctl/system call is decremented. If the device returns 0 bytes (valid per USB HID spec — some feature reports are optional or unsupported), the adjusted value becomes negative, and the slice expression panics:

- **Linux** `device_linux.go:270`: `buf[start : start+rv]` where `rv` is -1
- **macOS** `device_darwin.go:578`: `buf[1:ctx.len]` where `ctx.len` is 0
- **Windows** `device_windows.go:468`: `buf[1:n]` where `n` is 0

### Reproduction

Connect a Tripp Lite SMART1500LCDT UPS (VID=0x09AE, PID=0x2012) via USB on Linux. The device returns empty data for some HID feature reports (e.g., report ID 0x66). Any application polling the device crashes within seconds.

## Fix

Add bounds checks after adjusting for report ID. If the adjusted length is ≤ 0, return `(nil, nil)` — no data, no error. This is semantically correct: the device supports the report ID but has no data for it. Callers already handle nil data.

Also fixes the same potential issue in `getInputReport` on Linux (line 243).

### Changes

- `device_linux.go`: +6 lines (getFeatureReport + getInputReport)
- `device_darwin.go`: +3 lines (getFeatureReport)
- `device_windows.go`: +3 lines (getFeatureReport)

## Testing

- **Before fix:** Server crashes with unrecoverable panic within 5 seconds of connecting to the UPS
- **After fix:** Server runs indefinitely, gracefully skipping empty reports, UPS data reads successfully

Tested on Linux 5.15 (Ubuntu 22.04), Go 1.26.1, amd64.